### PR TITLE
Use `Bush.readyForHarvest()` when finding flowers

### DIFF
--- a/BetterBeehouses/framework/FlowerFinder.cs
+++ b/BetterBeehouses/framework/FlowerFinder.cs
@@ -52,7 +52,7 @@ namespace BetterBeehouses.framework
 								yield return new(crop, currentTile); //flower in pot
 
 							// bush in pot
-							if (Config.config.UseBushes && pot.bush.Value is Bush bush)
+							if (Config.config.UseBushes && pot.bush.Value is Bush bush && bush.readyForHarvest())
 							{
 								var shake = bush.GetShakeOffItem();
 								if (IndexIsFlower(shake))
@@ -93,7 +93,7 @@ namespace BetterBeehouses.framework
 					{
 						Vector2 targ = new(currentTile.X - i, currentTile.Y);
 						if (loc.terrainFeatures.TryGetValue(targ, out var tf) && tf is Bush bush &&
-							bush.getBoundingBox().Width > i && bush.inBloom())
+							bush.getBoundingBox().Width > i && bush.readyForHarvest())
 						{
 							var item = bush.GetShakeOffItem();
 							if (IndexIsFlower(item))


### PR DESCRIPTION
Pathos fulfilled my request to add `Bush.readyForHarvest()` to wrap `Bush.tileSheetOffset` with a more sensible name for knowing whether a `Bush` is harvestable as of SV v1.6.9+, so here are the adjustments to make use of that.

Previously the flower finder looked at whether the in-ground bush was in bloom or not and the in-pot bush didn't check bloom at all. This resulted in the in-pot bush always qualifying to flavor nearby honey and the in-ground bush qualifying during its entire bloom period, regardless of whether either were harvested or not.

Now both bush types will only qualify while they are harvestable, aligning with all the other honey flavor sources.